### PR TITLE
Fix missing python extensions

### DIFF
--- a/src/playbooks/roles/python/tasks/version.yml
+++ b/src/playbooks/roles/python/tasks/version.yml
@@ -16,7 +16,10 @@
       apt:
         name:
           - g++
+          - libbz2-dev
           - libffi-dev
+          - libreadline-dev
+          - libsqlite3-dev
           - libssl-dev
           - make
           - zlib1g-dev

--- a/src/playbooks/roles/python/tasks/version.yml
+++ b/src/playbooks/roles/python/tasks/version.yml
@@ -24,6 +24,11 @@
       shell: |-
         . ~/.bashrc.d/pyenv.bashrc
         pyenv install -s -k 3.7.3
+      register: install_result
+    - name: show stderr of python 3.7.3 installation and check whether WARNING exists
+      debug:
+        msg: "{{ install_result.stderr_lines }}"
+      failed_when: "{{ install_result.stderr_lines | select('match', '^WARNING: .*$') | list | length > 0 }}"
     - name: set global python version to 3.7.3
       shell: |-
         . ~/.bashrc.d/pyenv.bashrc


### PR DESCRIPTION
#85 の考慮漏れにより以下パッケージが使用できない状態となっている問題の修正

- `bz2`
- `sqlite3`

この問題は以下2つの apt パッケージのインストール処理を削除したことが原因

- `libbz2-dev`
- `libsqlite3-dev`

必要なパッケージ一覧は以下を参照
https://github.com/pyenv/pyenv/wiki/common-build-problems#prerequisites