### PR TITLE
Fix CI status when test_pv fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,7 @@ jobs:
       - test_git
       - test_nkf
       - test_prompt
+      - test_pv
       - test_python
       - test_rust
       - test_shellcheck


### PR DESCRIPTION
CI status must be failure if test_pv fails