### PR TITLE
Resolve failure in python role

### DIFF
--- a/src/playbooks/roles/python/tasks/version.yml
+++ b/src/playbooks/roles/python/tasks/version.yml
@@ -18,6 +18,7 @@
           - g++
           - libbz2-dev
           - libffi-dev
+          - liblzma-dev
           - libreadline-dev
           - libsqlite3-dev
           - libssl-dev


### PR DESCRIPTION
> WARNING: The Python lzma extension was not compiled. Missing the lzma lib?